### PR TITLE
Replace Ladder Network link to be current

### DIFF
--- a/pages/substrate-users.json
+++ b/pages/substrate-users.json
@@ -76,7 +76,7 @@
 		{
 			"name": "Ladder Network",
 			"image": "assets/logos/laddernetwork.png",
-			"link": "http://laddernetwork.io/"
+			"link": "https://github.com/laddernetwork"
 		},
 		{
 			"name": "Asure Network",


### PR DESCRIPTION
laddernetwork.io doesn't work