### PR TITLE
Fixing typo on Stake Technologies

### DIFF
--- a/pages/substrate-users.json
+++ b/pages/substrate-users.json
@@ -96,7 +96,7 @@
 		{
 			"name": "Stake Technologies",
 			"image": "assets/logos/stake-technologies.png",
-			"link": "https://staked.co.jp/"
+			"link": "https://stake.co.jp/"
 		},
 		{
 			"name": "Speckle OS",


### PR DESCRIPTION
Stake Technologies pointed out that their link was broken on Substrate Website.  It's suppose to be https://stake.co.jp instead of https://staked.co.jp

